### PR TITLE
Fixes typo in the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ In ADR, the _Domain_ and the _Responder_ do not "update each other". The _Domain
 
 ### Separated Presentation
 
-There are hints of ADR, espeically the _Responder_ element, in [Separated Presentation](http://martinfowler.com/eaaDev/SeparatedPresentation.html). Although the article is well worth reading, Separated Presentation sounds more like a meta-pattern that describes the general concern of separating data from presentation, not a specific approach to doing so.
+There are hints of ADR, especially the _Responder_ element, in [Separated Presentation](http://martinfowler.com/eaaDev/SeparatedPresentation.html). Although the article is well worth reading, Separated Presentation sounds more like a meta-pattern that describes the general concern of separating data from presentation, not a specific approach to doing so.
 
 ## Examples of MVC vs ADR
 


### PR DESCRIPTION
`espeically ` should read `especially`